### PR TITLE
Fix brace placement around $kver variable

### DIFF
--- a/linux-modules-save
+++ b/linux-modules-save
@@ -15,7 +15,7 @@ while read -r line; do
             #
             # This is the removal case, so we save the kernel
             mkdir /usr/lib/modules/running-kernel
-            cp --archive --link /usr/lib/modules/{$kver}/{kernel,modules*} \
+            cp --archive --link /usr/lib/modules/${kver}/{kernel,modules*} \
                 /usr/lib/modules/running-kernel/
         fi
         # If we are re-removing the running kernel, (after removing + reinstalling),


### PR DESCRIPTION
There seems to be a set of misplaced braces in the save script, which causes the save hook to fail (see below). Fortunately, this is trivially fixed.

![image](https://github.com/VannTen/kernel-modules-hook/assets/42657792/5ae9a3a6-c942-404e-baa6-352bd3ea707e)
(notice the braces that remain around the kernel version)