### PR TITLE
Fix existence check for saved modules directory

### DIFF
--- a/linux-modules-restore
+++ b/linux-modules-restore
@@ -3,7 +3,7 @@
 kver=$(uname -r)
 while read -r line; do
     # We only care about the running kernel
-    if [[ "$line" == usr/lib/modules/$kver/vmlinuz && -d "${line/$kver/running-kernel}" ]];then
+    if [[ "$line" == usr/lib/modules/$kver/vmlinuz && -d "/usr/lib/modules/running-kernel" ]];then
         mount --mkdir --bind --options ro /usr/lib/modules/{running-kernel,$kver}
         # Mounting read-only since the only modification here should be unmounting
         # when rebooting or reinstalling the running kernel


### PR DESCRIPTION
The restore script attempts to check for the existence of the `/usr/lib/modules/running-kernel` directory before mounting it.

However, this check currently tests whether `/usr/lib/modules/running-kernel/vmlinuz` exists (it doesn't) and *is a directory* (it definitely isn't). As a result, the mount command is never run.

This PR rewrites the check to point to the correct directory, i.e. `.../running-kernel` itself.